### PR TITLE
Remove yum install package steps - speed up instance launch time

### DIFF
--- a/userdata.tpl
+++ b/userdata.tpl
@@ -14,11 +14,6 @@ echo "fs.inotify.max_user_watches=524288" >> /etc/sysctl.conf
 echo "fs.inotify.max_user_instances=512" >> /etc/sysctl.conf
 /sbin/sysctl -p /etc/sysctl.conf
 
-
-echo "### INSTALL PACKAGES"
-yum update -y
-yum install -y amazon-efs-utils aws-cli
-
 echo "### SETUP AGENT"
 
 echo "ECS_CLUSTER=${tf_cluster_name}" >> /etc/ecs/ecs.config


### PR DESCRIPTION
- aws cli already available in the base AMI
- efs utils not needed as the efs volume for netskope service/task is attached using [efs access points](https://github.com/mydeal-com-au/terraform-aws-ecs-app/blob/master/efs-access-point.tf).